### PR TITLE
Update Clipboard.ahk

### DIFF
--- a/Clipboard.ahk
+++ b/Clipboard.ahk
@@ -24,7 +24,7 @@ OnClipboardChange()
 	if(ToArray(Settings.Misc.IgnoredPrograms, "|").indexOf(owner))
 		return
 
-	if(WinActive("ahk_group ExplorerGroup") || WinActive("ahk_group DesktopGroup")|| IsDialog())
+	if(WinActive(("ahk_group ExplorerGroup") || WinActive("ahk_group DesktopGroup")|| IsDialog()) && !IsRenaming())
 		CreateFileFromClipboard()
 	else
 		ShowTip({Min : 1, Max : 2})


### PR DESCRIPTION
Found the bug from issue #423 - Outlook 2010 pasting explorer path as clip.txt (not text). It needs to be verified for other possible conflicts, but that solved that issue for me.
